### PR TITLE
add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ http://dinbror.dk/blog/blazy
 
 ### CDN
 
-`//cdn.jsdelivr.net/blazy/latest/mainfile` to link to the latest minified file on [jsDelivr](http://www.jsdelivr.com/#!blazy).
+`//cdn.jsdelivr.net/blazy/latest/blazy.min.js` to link to the latest minified file on [jsDelivr](http://www.jsdelivr.com/#!blazy).
 Exchange `latest` with the specific version number if you want to lock it in.
 
 ## WHY BE LAZY? ##


### PR DESCRIPTION
Sometime in the next few months, there will be an automated script to upload.  In the mean while, you, I, or anyone can upload to [jsDelivr](https://github.com/jsdelivr/jsdelivr/tree/master/files/blazy), as long as it is only the `.min` file & has the proper header.
