### PR TITLE
Update bower.json to match the main script name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "bLazy",
-	"main": "bLazy.js",
+	"main": "blazy.js",
 	"version": "1.2.2",
 	"description": "bLazy is a lightweight script for lazy loading and multi-serving images",
 	"homepage": "https://github.com/dinbror/blazy",


### PR DESCRIPTION
Some build tools (like Sprockets) might be too picky being case sensitive and won't work as expected when the filename and the `main` value aren't exactly the same.
