### PR TITLE
Fix "invalid-meta" bower warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,6 @@
 	"license": "MIT",
 	"moduleType": [
     		"amd"
-  	]
+  	],
+  	"ignore": []
 }


### PR DESCRIPTION
Bower complains about a missing `ignore` property when installing Blazy, this hides the warning.
