### PR TITLE
Better IE7/IE8 support

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -183,7 +183,7 @@
  		var nodelist 	= document.querySelectorAll(selector);
  		count 			= nodelist.length;
  		//converting nodelist to array
- 		for(var i = count; i--; images.unshift(nodelist[i])){}
+ 		for(var i = count; i--; images.push(nodelist[i])){}
 	 }
 	 
 	 function saveWinOffset(){


### PR DESCRIPTION
Blazy currently uses “unshift” which is not supported by IE8 and earlier according to http://www.w3schools.com/jsref/jsref_unshift.asp. Since there is an IE7 workaround for “querySelectorAll”, those versions were supposed to be supported. It can be replaced by “push” which is supported. The only difference is the order of lazy loading.
