### PR TITLE
Load background images last

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -48,6 +48,7 @@
 		options.errorClass 	= options.errorClass 	|| 'b-error';
 		options.breakpoints	= options.breakpoints	|| false;
 		options.successClass 	= options.successClass 	|| 'b-loaded';
+		options.lateClass 	= options.lateClass 	|| 'b-late';
 		options.src = source 	= options.src		|| 'data-src';
 		isRetina		= window.devicePixelRatio > 1;
 		//throttle, ensures that we don't call the functions too often
@@ -182,8 +183,8 @@
 	 function createImageArray(selector) {
  		var nodelist 	= document.querySelectorAll(selector);
  		count 			= nodelist.length;
- 		//converting nodelist to array
- 		for(var i = count; i--; images.unshift(nodelist[i])){}
+ 		//converting nodelist to array, background images will be added to end 
+		if (nodelist[i].classList.contains(options.lateClass) || nodelist[i].nodeName.toLowerCase() !== 'img') {images.push(nodelist[i])} else {images.unshift(nodelist[i])}
 	 }
 	 
 	 function saveWinOffset(){


### PR DESCRIPTION
Since there is a maximum to the amount of HTTP-requests which can be active at the same time, I suggest to differ between background and foreground images. The background images will be handled last. This change doesn’t work in IE7 and IE8, since “unshift” is used which isn’t supported in those browsers according to http://www.w3schools.com/jsref/jsref_unshift.asp. The original V1.2.2 has the same limitation. The new code is also depending on “classList” support which breaks IE9. This can be handled by adding https://github.com/eligrey/classList.js, or incorporating the JavaScript shim by Mozilla from this page: https://developer.mozilla.org/en-US/docs/Web/API/Element.classList. 
A background image is either an image which is defined as a background-image in the css, or an image with the new class “b-late” to support multi-layer designs.
