### PR TITLE
add option to force load hidden images

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -72,8 +72,8 @@
 	Blazy.prototype.revalidate = function() {
  		initialize();
    	};
-	Blazy.prototype.load = function(element){
-		if(!isElementLoaded(element)) loadImage(element);
+	Blazy.prototype.load = function(element, force){
+		if(!isElementLoaded(element)) loadImage(element, force);
 	};
 	Blazy.prototype.destroy = function(){
 		if(options.container){
@@ -125,9 +125,9 @@
 		}
 	}
 	
-	function loadImage(ele){
+	function loadImage(ele, force){
 		// if element is visible
-		if(ele.offsetWidth > 0 && ele.offsetHeight > 0) {
+		if ((ele.offsetWidth > 0 && ele.offsetHeight > 0) || (force === true)) {
 			var dataSrc = ele.getAttribute(source) || ele.getAttribute(options.src); // fallback to default data-src
 			if(dataSrc) {
 				var dataSrcSplitted = dataSrc.split(options.separator);


### PR DESCRIPTION
in a project i have images in hidden tabs, so they are not rendered (b'cose of **display:none**) 
```
ele.offsetWidth = ele.offsetHeight = 0
```
even when i used you public function **load(item)**

so it's a good idea to add an option to force them to load, like **load(item, true)**