### PR TITLE
Allow changing of throttle delays via options

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -49,10 +49,13 @@
 		options.breakpoints	= options.breakpoints	|| false;
 		options.successClass 	= options.successClass 	|| 'b-loaded';
 		options.src = source 	= options.src		|| 'data-src';
+		options.tValidateDelay	= options.tValidateDelay|| 25;
+		options.wValidateDelay	= options.wValidateDelay|| 50;
+		
 		isRetina		= window.devicePixelRatio > 1;
 		//throttle, ensures that we don't call the functions too often
-		validateT		= throttle(validate, 25); 
-		saveWinOffsetT		= throttle(saveWinOffset, 50);
+		validateT		= throttle(validate, options.tValidateDelay); 
+		saveWinOffsetT		= throttle(saveWinOffset, options.wValidateDelay);
 
 		saveWinOffset();		
 		//handle multi-served image src

--- a/blazy.js
+++ b/blazy.js
@@ -49,13 +49,13 @@
 		options.breakpoints	= options.breakpoints	|| false;
 		options.successClass 	= options.successClass 	|| 'b-loaded';
 		options.src = source 	= options.src		|| 'data-src';
-		options.tValidateDelay	= options.tValidateDelay|| 25;
-		options.wValidateDelay	= options.wValidateDelay|| 50;
+		options.validateDelay	= options.validateDelay	|| 25;
+		options.saveWinOffsetDelay	= options.saveWinOffsetDelay	|| 50;
 		
 		isRetina		= window.devicePixelRatio > 1;
 		//throttle, ensures that we don't call the functions too often
-		validateT		= throttle(validate, options.tValidateDelay); 
-		saveWinOffsetT		= throttle(saveWinOffset, options.wValidateDelay);
+		validateT		= throttle(validate, options.validateDelay); 
+		saveWinOffsetT		= throttle(saveWinOffset, options.saveWinOffsetDelay);
 
 		saveWinOffset();		
 		//handle multi-served image src


### PR DESCRIPTION
Thankyou for this great little library!

My use case involves displaying hundreds of images on a single page. Some people scroll quickly to the bottom or middle of the page and I don't want all the images to load in the interim, i'll be setting my throttle somewhere between 250ms and 750ms.

The default values haven't changed and the pull request is completely innocuous to the library, it can be merged without any concerns.

The less hard-coded unchangeable values.. the better, even if they are slightly obscure :smiley: 

