### PR TITLE
Update blazy.js

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -191,7 +191,10 @@
     }
 
     function createImageArray(selector) {
-        return [].slice.call(document.querySelectorAll(selector));
+      if( Object.prototype.toString.call( selector ) === '[object Array]' ) {
+        return selector;
+      }
+      return [].slice.call(document.querySelectorAll(selector));
     }
 
     function saveViewportOffset(offset) {


### PR DESCRIPTION
Just a thought about another way to past directly an array into the selector option.
That way we could parse the DOM before Blazy do it, and get the images to lazyload via others methods than the classes...
For exemple I would like to get my image by the 'data-src' attribute.
Of course this will be a problem for the scope.revalidate function ....
Maybe we could also past an argument in revalidate() (like in load(element, force)) to retrieve the new array if it pasted ?