### PR TITLE
Fix transfering multiple images when using srcset

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -192,8 +192,8 @@
                     var onLoadHandler = function() {
                         // Is element an image
                         if (isImage) {
-                            setSrc(ele, src); //src
                             handleSource(ele, _attrSrcset, options.srcset); //srcset
+                            setSrc(ele, src); //src
                             //picture element
                             var parent = ele.parentNode;
                             if (parent && equal(parent, 'picture')) {
@@ -211,6 +211,12 @@
                     };
                     bindEvent(img, 'error', onErrorHandler);
                     bindEvent(img, 'load', onLoadHandler);
+                    
+                    // preloading srcset
+                    var dataSrc = ele.getAttribute(options.srcset);
+                    if (dataSrc) {
+                    	img[_attrSrcset] = dataSrc;
+                    }
                     setSrc(img, src); //preload
                 } else { // An item with src like iframe, unity, simpelvideo etc
                     setSrc(ele, src);


### PR DESCRIPTION
Setting srcset attribute before src attribute on the img  element, to prevent two images being transferred from Firefox and Chrome on hidpi displays.
Also added srcset attribute to img preload.