### PR TITLE
change event listener to passive listener

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -284,7 +284,7 @@
         if (ele.attachEvent) {
             ele.attachEvent && ele.attachEvent('on' + type, fn);
         } else {
-            ele.addEventListener(type, fn, false);
+            ele.addEventListener(type, fn, { capture: false, passive: true });
         }
     }
 
@@ -292,7 +292,7 @@
         if (ele.detachEvent) {
             ele.detachEvent && ele.detachEvent('on' + type, fn);
         } else {
-            ele.removeEventListener(type, fn, false);
+            ele.removeEventListener(type, fn, { capture: false, passive: true });
         }
     }
 


### PR DESCRIPTION
Passive event listeners can't call `preventDefault` function which boosts the scrolling performance.
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

need to update the minified version