### PR TITLE
Change where revalidate gets its options from

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -71,7 +71,7 @@
         /* public functions
          ************************************/
         scope.revalidate = function() {
-            initialize(this);
+            initialize(scope);
         };
         scope.load = function(elements, force) {
             var opt = this.options;


### PR DESCRIPTION
It was defaulting to "window" for this. Now uses private scrope for the options.