### PR TITLE
Lazy loading script-tags

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -182,7 +182,7 @@
         var rect = ele.getBoundingClientRect();
 
         if(ele.tagName == 'SCRIPT') {
-            rect = $(ele).parents('div')[0].getBoundingClientRect();
+            rect = $(ele).parents('div, p, article').not(':hidden')[0].getBoundingClientRect();
 
             if($(ele).attr('data-parent')) {
                 rect = $('#' + $(ele).attr('data-parent'))[0].getBoundingClientRect();

--- a/blazy.js
+++ b/blazy.js
@@ -148,11 +148,9 @@
 
     function validate(self) {
         var util = self._util;
-        var element;
-        var element_;
         for (var i = 0; i < util.count; i++) {
-            element = util.elements[i];
-            element_ = undefined;
+            var element = util.elements[i];
+            var element_ = undefined;
 
             if($(element)[0].tagName == 'SCRIPT') {
                 element_ = element;

--- a/blazy.js
+++ b/blazy.js
@@ -156,10 +156,14 @@
 
             if($(element)[0].tagName == 'SCRIPT') {
                 element_ = element;
-                element = $(element).parent()[0];
+                element = $(element).parents('div')[0];
+
+                if($(element_).attr('data-parent')) {
+                    element = $('#' + $(element_).attr('data-parent'))[0];                    
+                }
             }
 
-            if (elementInView(element, self.options) || hasClass(element, self.options.successClass) || $(element)[0].tagName == 'SCRIPT') {
+            if (elementInView(element_ || element, self.options) || hasClass(element, self.options.successClass) || (element_ != undefined && elementInView(element_ || element, self.options) && $(element_)[0].tagName == 'SCRIPT')) {
 
                 if(element_ !== undefined && $(element_)[0].tagName == 'SCRIPT') {
                     element = element_;
@@ -180,8 +184,11 @@
         var rect = ele.getBoundingClientRect();
 
         if(ele.tagName == 'SCRIPT') {
-            rect = $(ele).parent()[0];
-            console.log('rect', rect);
+            rect = $(ele).parents('div')[0].getBoundingClientRect();
+
+            if($(ele).attr('data-parent')) {
+                rect = $('#' + $(ele).attr('data-parent'))[0].getBoundingClientRect();
+            }
         }
 
         if(options.container && _supportClosest){
@@ -226,6 +233,10 @@
         if($(ele)[0].tagName == 'SCRIPT') {
             ele_ = ele;
             ele = $(ele).parent()[0];
+
+            if($(ele_).attr('data-parent')) {
+                ele = $('#' + $(ele_).attr('data-parent'))[0];                    
+            }
         }
 
         if (!hasClass(ele, options.successClass) && (force || options.loadInvisible || (ele.offsetWidth > 0 && ele.offsetHeight > 0))) {

--- a/blazy.js
+++ b/blazy.js
@@ -148,9 +148,23 @@
 
     function validate(self) {
         var util = self._util;
+        var element;
+        var element_;
         for (var i = 0; i < util.count; i++) {
-            var element = util.elements[i];
-            if (elementInView(element, self.options) || hasClass(element, self.options.successClass)) {
+            element = util.elements[i];
+            element_ = undefined;
+
+            if($(element)[0].tagName == 'SCRIPT') {
+                element_ = element;
+                element = $(element).parent()[0];
+            }
+
+            if (elementInView(element, self.options) || hasClass(element, self.options.successClass) || $(element)[0].tagName == 'SCRIPT') {
+
+                if(element_ !== undefined && $(element_)[0].tagName == 'SCRIPT') {
+                    element = element_;
+                }
+              
                 self.load(element);
                 util.elements.splice(i, 1);
                 util.count--;
@@ -164,6 +178,11 @@
 
     function elementInView(ele, options) {
         var rect = ele.getBoundingClientRect();
+
+        if(ele.tagName == 'SCRIPT') {
+            rect = $(ele).parent()[0];
+            console.log('rect', rect);
+        }
 
         if(options.container && _supportClosest){
             // Is element inside a container?
@@ -202,7 +221,18 @@
 
     function loadElement(ele, force, options) {
         // if element is visible, not loaded or forced
+        var ele_;
+
+        if($(ele)[0].tagName == 'SCRIPT') {
+            ele_ = ele;
+            ele = $(ele).parent()[0];
+        }
+
         if (!hasClass(ele, options.successClass) && (force || options.loadInvisible || (ele.offsetWidth > 0 && ele.offsetHeight > 0))) {
+            if(ele_ !== undefined && $(ele_)[0].tagName == 'SCRIPT') {
+                ele = ele_;
+            }
+          
             var dataSrc = getAttr(ele, _source) || getAttr(ele, options.src); // fallback to default 'data-src'
             if (dataSrc) {
                 var dataSrcSplitted = dataSrc.split(options.separator);
@@ -250,8 +280,17 @@
                     handleSources(img, src, srcset); // Preload
 
                 } else { // An item with src like iframe, unity games, simpel video etc
-                    ele.src = src;
-                    itemLoaded(ele, options);
+                    //ele.src = src;
+                    //itemLoaded(ele, options);
+
+                    if($(ele)[0].tagName == 'SCRIPT') {
+                        $.getScript($(ele_).attr('data-src'));
+                        itemLoaded(ele, options);
+                        $(ele_).remove();
+                    } else {
+                        ele.src = src;
+                        itemLoaded(ele, options);
+                    }
                 }
             } else {
                 // video with child source


### PR DESCRIPTION
The changes let me now load script-tags dynamically, when a defined parent element is shown in the viewport. You can also omit the parent id, in that case the real parent is used to load the script.

_Following example shows the usage with google-maps:_
```
<div id="map"></div>
<script class="b-lazy" data-parent="map" data-src="https://maps.googleapis.com/maps/api/js?key=mySuperSecretAPIkey&#038;callback=initMap" async defer></script>
```