### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bower install blazy --save
 
 ### CDN
 If you don't want to host the script yourself you can link to the latest minified file:  
-`//cdn.jsdelivr.net/blazy/latest/blazy.min.js` on [jsDelivr](http://www.jsdelivr.com/#!blazy).
+`//cdn.jsdelivr.net/npm/blazy@latest/blazy.min.js` on [jsDelivr](http://www.jsdelivr.com/#!blazy).
 Exchange `latest` with the specific version number if you want to lock it in.
 
 ## WHY BE LAZY? ##


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.
I updated the link now so you don't forget to do it when you release a new version.

Feel free to ping me if you have any questions regarding this change.