### PR TITLE
Blazy visibility determination, max-width and max-height

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -194,11 +194,12 @@
 
     function inView(rect, viewport){
         // Intersection
-        return (rect.width > 0 && rect.height > 0) &&
-               rect.right >= viewport.left &&
+        return rect.right >= viewport.left &&
                rect.bottom >= viewport.top && 
                rect.left <= viewport.right && 
-               rect.top <= viewport.bottom;
+               rect.top <= viewport.bottom &&
+               (rect.width > 0 && rect.height > 0);
+
     }
 
     function loadElement(ele, force, options) {

--- a/blazy.js
+++ b/blazy.js
@@ -194,7 +194,8 @@
 
     function inView(rect, viewport){
         // Intersection
-        return rect.right >= viewport.left &&
+        return (rect.width > 0 && rect.height > 0) &&
+               rect.right >= viewport.left &&
                rect.bottom >= viewport.top && 
                rect.left <= viewport.right && 
                rect.top <= viewport.bottom;


### PR DESCRIPTION
I have created a fiddle demonstrating the issue here: https://jsfiddle.net/8us8m1wb/1/

Using a css style with "max-height: 0; overflow:hidden" is an effective way to hide an tree in the page in a way that can be animated through css transitions.

I am using the 'container' feature as well. The parent container has max-height:0 (or max-width) and the child element is not displayed, but blazy still loads it.

Checking the width and height of the rect fixes this issue