### PR TITLE
load dummy image to avoid duplicate request getting sent on lazy load

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -227,7 +227,7 @@
                         // Is element an image
                         if (isImage) {
                             if(!isPicture) {
-                                handleSources(ele, src, srcset);
+                                handleSources(ele, "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==", srcset);
                             }
                         // or background-image
                         } else {


### PR DESCRIPTION
Images are loading twice as part of lazy load, this PR will avoid the duplicate by having a dummy image src attribute and then replacing it with the loaded image src