### PR TITLE
Make sure the element is in the DOM before calling getBoundingClientR…

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -163,6 +163,21 @@
     }
 
     function elementInView(ele, options) {
+        var attrValue = null;
+        var isNotInDOM = null;
+
+        if (ele.nodeName && ele.nodeName.toLowerCase() === 'img') {
+            attrValue = ele.getAttribute('src');
+            isNotInDOM = document.querySelectorAll('img[src="' + attrValue + '"]').length <= 0;
+        } else {
+            attrValue = ele.getAttribute('data-src');
+            isNotInDOM = document.querySelectorAll('[data-src="' + attrValue + '"]').length <= 0;
+        }
+
+        if (isNotInDOM) {
+            return;
+        }
+        
         var rect = ele.getBoundingClientRect();
 
         if(options.container && _supportClosest){


### PR DESCRIPTION
On some browsers (I think mostly old IE like < IE11) the call to `ele.getBoundingClientRect();` threw an uncaught exception if the element wasn't in the DOM. I added a check before the call.